### PR TITLE
Add moving platform momentum

### DIFF
--- a/boi/Assets/RailScript.cs
+++ b/boi/Assets/RailScript.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RailScript : MonoBehaviour
+{
+    [SerializeField]
+    public Transform[] points;
+    public bool canReturn;
+    private Vector2 currentSpoint;
+    private Vector2 currentEpoint;
+    private float mpb = 0;
+    public float waitPercent;
+    public float goPercent;
+    private int i = 1;
+    private FollowerOfTheRhythm tempo;
+    private bool coroutineAllowed = true;
+    private bool returning = false;
+
+    public Vector3 MovementVector { get; private set; }
+    void Start()
+    {
+        tempo = GetComponent<FollowerOfTheRhythm>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        mpb = 60f / tempo.getBpm();
+        if (coroutineAllowed)
+        {
+            currentSpoint = transform.position;
+            currentEpoint = points[i].position;
+            StartCoroutine(MoveObjectOnBeat(currentSpoint, currentEpoint));
+
+        }
+    }
+
+    private IEnumerator MoveObjectOnBeat(Vector2 start, Vector2 end)
+    {
+        float waitTime = 0f;
+        coroutineAllowed = false;
+        float time = 0f;
+        while (transform.position.x != end.x || transform.position.y != end.y)
+        {
+            time += Time.deltaTime / mpb * goPercent;
+            MovementVector = transform.position;
+            transform.position = Vector3.Lerp(start, end, time);
+            MovementVector = transform.position - MovementVector;
+            yield return null;
+        }
+        waitTime = Time.time + mpb * waitPercent;
+        while (Time.time < waitTime)
+        {
+            MovementVector = new Vector3();
+            yield return null;
+        }
+        if (i == points.Length - 1)
+        {
+            if (canReturn)
+                returning = true;
+            else
+            {
+                i = 0;
+                transform.position = points[0].position;
+            }
+
+        }
+        if (i <= 0)
+            returning = false;
+        if (i < points.Length - 1 && !returning)
+            i++;
+        else if (returning && i > 0 && canReturn)
+        {
+            i--;
+        }
+        coroutineAllowed = true;
+    }
+
+}

--- a/boi/Assets/RailScript.cs.meta
+++ b/boi/Assets/RailScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23ffee5af5377a9448fb44ea534ba09b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/boi/Assets/Ressources/LevelDesign/Obstacles/RailedPlatform.prefab
+++ b/boi/Assets/Ressources/LevelDesign/Obstacles/RailedPlatform.prefab
@@ -1,0 +1,2545 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4565057688973027104
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8884337366633749573}
+  - component: {fileID: 7027976632935924273}
+  - component: {fileID: 4565057688973027111}
+  - component: {fileID: 4565057688973027110}
+  m_Layer: 0
+  m_Name: Platform
+  m_TagString: MovingPlatform
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8884337366633749573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4565057688973027104}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 6758330085372458394}
+  - {fileID: 8069599806026604176}
+  - {fileID: 4485649657213202083}
+  - {fileID: 10248660928260764}
+  - {fileID: 13265852620703333}
+  - {fileID: 5755455616924502466}
+  - {fileID: 6600360045262585993}
+  - {fileID: 8543226210603178879}
+  - {fileID: 94286993490285793}
+  - {fileID: 574004210192211431}
+  - {fileID: 2551489536645340011}
+  - {fileID: 5130412318847306362}
+  - {fileID: 611966461731110178}
+  - {fileID: 6926622703757689802}
+  - {fileID: 7065676079988366007}
+  - {fileID: 148706045822951371}
+  - {fileID: 2322336668894259963}
+  - {fileID: 841482942916239666}
+  - {fileID: 2347154697819657428}
+  - {fileID: 454653744941368490}
+  - {fileID: 5189063018474331006}
+  - {fileID: 2086295127822305137}
+  - {fileID: 5307772241167232791}
+  - {fileID: 1594420262772090814}
+  - {fileID: 7704940444631436434}
+  - {fileID: 8525842004060101838}
+  - {fileID: 5023264832313924812}
+  m_Father: {fileID: 7027976633168277069}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7027976632935924273
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4565057688973027104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0879e20ca3028724f821258f2645dffd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4565057688973027111
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4565057688973027104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23ffee5af5377a9448fb44ea534ba09b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  points:
+  - {fileID: 7027976634834281818}
+  - {fileID: 7027976634566956124}
+  - {fileID: 7027976634938007185}
+  canReturn: 1
+  waitPercent: 0
+  goPercent: 0.3
+--- !u!114 &4565057688973027110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4565057688973027104}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a663d29581b43144bcb5257a33bf2d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7027976633168277070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7027976633168277069}
+  m_Layer: 0
+  m_Name: RailedPlatform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7027976633168277069
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027976633168277070}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 5.3414955, y: -16.41, z: 62.33594}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7027976633500489242}
+  - {fileID: 8884337366633749573}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7027976633500489243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7027976633500489242}
+  m_Layer: 0
+  m_Name: Rails
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7027976633500489242
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027976633500489243}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.892623, y: -13.799841, z: -80.98818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7027976634834281818}
+  - {fileID: 7027976634566956124}
+  - {fileID: 7027976634938007185}
+  m_Father: {fileID: 7027976633168277069}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7027976634566956125
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7027976634566956124}
+  m_Layer: 0
+  m_Name: 1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7027976634566956124
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027976634566956125}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -27.157375, y: 13.799841, z: 80.98818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7027976633500489242}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7027976634834281819
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7027976634834281818}
+  m_Layer: 0
+  m_Name: 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7027976634834281818
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027976634834281819}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.892623, y: 23.059841, z: 80.98818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7027976633500489242}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7027976634938007186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7027976634938007185}
+  m_Layer: 0
+  m_Name: 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7027976634938007185
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7027976634938007186}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 2.892623, y: 13.799841, z: 80.98818}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7027976633500489242}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &874538671444985225
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (144)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.472916
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &2347154697819657428 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 874538671444985225}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &903711076794923942
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (142)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -27.885925
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &2322336668894259963 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 903711076794923942}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1141819451669416502
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (135)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.152924
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &2551489536645340011 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1141819451669416502}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1364592964176166910
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (127)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9550781
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &4485649657213202083 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 1364592964176166910}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2652088892602412159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (138)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -21.523926
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &611966461731110178 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2652088892602412159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2818607738403074159
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (143)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -26.293915
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &841482942916239666 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 2818607738403074159}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3098328826194957815
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (118)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7.203
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &454653744941368490 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3098328826194957815}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3118598995600592058
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (134)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.929123
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &574004210192211431 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3118598995600592058}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3212282115751246785
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (128)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.77207947
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &10248660928260764 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3212282115751246785}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3215316918921959224
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (129)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.36409
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &13265852620703333 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3215316918921959224}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3314298648783848892
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (133)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -18.335907
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &94286993490285793 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3314298648783848892}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3359817085516959382
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (141)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -29.472916
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &148706045822951371 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3359817085516959382}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3477969510546675244
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (120)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -10.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &2086295127822305137 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3477969510546675244}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4220079845730367203
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (122)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.605
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &1594420262772090814 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 4220079845730367203}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4849465089133825997
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (126)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.5420837
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &8069599806026604176 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 4849465089133825997}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5070290161232780751
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (123)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -4.0079193
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &7704940444631436434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5070290161232780751}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5517039478085915287
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (139)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -23.115906
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &6926622703757689802 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5517039478085915287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5674089675368844266
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (140)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -24.702911
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &7065676079988366007 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 5674089675368844266}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6503086208735971874
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (132)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -16.743912
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &8543226210603178879 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6503086208735971874}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6548753565188836755
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (124)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.4159088
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &8525842004060101838 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 6548753565188836755}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7165021299804461215
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (130)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.8491211
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &5755455616924502466 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7165021299804461215}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7256277394401217059
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (119)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -8.796
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &5189063018474331006 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7256277394401217059}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7284790313423453770
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (121)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.8149109
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &5307772241167232791 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7284790313423453770}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7567736545687670161
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.959999
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8600006
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &5023264832313924812 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7567736545687670161}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7746994383233391399
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (136)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -13.558
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &5130412318847306362 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 7746994383233391399}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8176938151873995975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (125)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.134079
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &6758330085372458394 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8176938151873995975}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8586404023223112148
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8884337366633749573}
+    m_Modifications:
+    - target: {fileID: 3220135902311092570, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_Name
+      value: EarthGround (131)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092571, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_TagString
+      value: MovingPlatform
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -19.922913
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -2.8544655
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.335934
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 843911522611b3c489e3435e4b3b36d4, type: 3}
+--- !u!4 &6600360045262585993 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3220135902311092573, guid: 843911522611b3c489e3435e4b3b36d4,
+    type: 3}
+  m_PrefabInstance: {fileID: 8586404023223112148}
+  m_PrefabAsset: {fileID: 0}

--- a/boi/Assets/Ressources/LevelDesign/Obstacles/RailedPlatform.prefab.meta
+++ b/boi/Assets/Ressources/LevelDesign/Obstacles/RailedPlatform.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 67380e98e3eb9444c9ccdb0dcf9a153b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/boi/Assets/Ressources/Player/Prefabs/PLAYER.prefab
+++ b/boi/Assets/Ressources/Player/Prefabs/PLAYER.prefab
@@ -250,6 +250,7 @@ MonoBehaviour:
   bounceSpeed: 60
   pushBlockSpeed: 0.1
   minDropDistance: 0.4
+  groundMomentumDeceleration: 0.1
 --- !u!114 &2758391791921759296
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/boi/Assets/Ressources/Scenes/MovingPlatform.unity
+++ b/boi/Assets/Ressources/Scenes/MovingPlatform.unity
@@ -1,0 +1,566 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &89954859
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.3414955
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -16.41
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.33594
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277069, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7027976633168277070, guid: 67380e98e3eb9444c9ccdb0dcf9a153b,
+        type: 3}
+      propertyPath: m_Name
+      value: RailedPlatform
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 67380e98e3eb9444c9ccdb0dcf9a153b, type: 3}
+--- !u!1001 &183112149
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3133395599572617354, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_Name
+      value: GravityBox
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -61.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -11.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3133395599572617355, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7ee09bc8acd30dc4cb7487559cdcc8a2, type: 3}
+--- !u!1 &944126880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 944126883}
+  - component: {fileID: 944126882}
+  - component: {fileID: 944126881}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &944126881
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944126880}
+  m_Enabled: 1
+--- !u!20 &944126882
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944126880}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 10
+    height: 10
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 1
+  orthographic size: 15
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &944126883
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 944126880}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -6.2, y: -13, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1747877228
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324885, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 142829629331324886, guid: aebb328f3cfce744ab644cab2c43556e,
+        type: 3}
+      propertyPath: m_Name
+      value: Rythm
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: aebb328f3cfce744ab644cab2c43556e, type: 3}
+--- !u!1001 &1806490036
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -5.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -15.95
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759298, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758391791921759308, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8,
+        type: 3}
+      propertyPath: m_Name
+      value: PLAYER
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b8ff4a2382d64cbab39b8a971a3dbd8, type: 3}
+--- !u!1001 &1929879712
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.3414955
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -24.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 62.33594
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1928633833784975222, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 3339172698489965303, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_TagString
+      value: WALL
+      objectReference: {fileID: 0}
+    - target: {fileID: 6832581083213964307, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_Name
+      value: Ground (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6832581083213964307, guid: ea6562ea9caa1bd47b1cd76214dae9f4,
+        type: 3}
+      propertyPath: m_TagString
+      value: Untagged
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ea6562ea9caa1bd47b1cd76214dae9f4, type: 3}

--- a/boi/Assets/Ressources/Scenes/MovingPlatform.unity.meta
+++ b/boi/Assets/Ressources/Scenes/MovingPlatform.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 045323396d38c324ea0ed1de08e27305
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/boi/ProjectSettings/TagManager.asset
+++ b/boi/ProjectSettings/TagManager.asset
@@ -15,6 +15,8 @@ TagManager:
   - CHECKPOINT
   - OGRE WEAKSPOT
   - BOUNCE
+  - GravSwap
+  - MovingPlatform
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
New prefab `Railed Platform` that takes the player during its movement. This is done through the RailScript and  [KeepMomentum()](https://github.com/One-Drill/RhythmBoi/compare/ImprovedCharacter...character/moving-platform?expand=1#diff-9138b07c559825cfbd615208d1fe5f10R93-R111) method on CharacterController.cs.

Added @Smerelo 's [RailScript](https://github.com/One-Drill/RhythmBoi/compare/ImprovedCharacter...character/moving-platform?expand=1#diff-017740b77bd9e3e4673632d025b92539)

RailScript: Add MovementVector property, movement vector of the object
in the last frame please [check it out](https://github.com/One-Drill/RhythmBoi/compare/ImprovedCharacter...character/moving-platform?expand=1#diff-017740b77bd9e3e4673632d025b92539R47-R49) @Smerelo senpai.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/53628737/79125466-8c472900-7d9e-11ea-846b-1a0113051672.gif)